### PR TITLE
Correct indentation of if/endif

### DIFF
--- a/alertmanager/config/alertmanager.yml.tmpl
+++ b/alertmanager/config/alertmanager.yml.tmpl
@@ -1,8 +1,8 @@
 global:
  resolve_timeout: 1m
- %{ if slack_url != "" ~}
+%{ if slack_url != "" ~}
  slack_api_url: '${slack_url}'
- %{ endif ~}
+%{ endif ~}
 
 route:
  receiver: 'slack-notifications'


### PR DESCRIPTION
When if/endif is not the beginning of the line, the alertmanager config
fails to evaluate the value of slack_api_url

Alertmanager crashes, with this in the logs
```
msg="Loading configuration file failed" file=alertmanager.yml err="yaml: line 3: mapping values are not allowed in this context"
```



