### PR TITLE
Update plugins.txt adding Google Sheets Data Source

### DIFF
--- a/grafana/config/plugins.txt
+++ b/grafana/config/plugins.txt
@@ -2,3 +2,4 @@ grafana-piechart-panel
 aidanmountford-html-panel
 simpod-json-datasource
 yesoreyeram-boomtable-panel
+grafana-googlesheets-datasource


### PR DESCRIPTION
Adding the google Sheet Grafana plugin into available data sources, this will need a config, but working on that as another PR

It does allow for Manual Linking at this point 

https://grafana-dev-get-into-teaching.london.cloudapps.digital/d/SW1fFbsMk/new-dashboard-copy?editPanel=2&orgId=1

