### PR TITLE
Added Google-Sheets-Configuration

### DIFF
--- a/grafana/config.tf
+++ b/grafana/config.tf
@@ -33,6 +33,10 @@ data archive_file config {
     filename = "datasources/influxdb.yml"
   }
 
+  source {
+    content  = templatefile("${path.module}/datasources/google-sheets.yml.tmpl", local.grafana_datasource_variables)
+    filename = "datasources/google-sheets.yml"
+  }
 
   dynamic "source" {
     for_each = local.dashboards

--- a/grafana/datasources/google-sheets.yml.tmpl
+++ b/grafana/datasources/google-sheets.yml.tmpl
@@ -1,0 +1,18 @@
+%{ if google_jwt != "" }
+apiVersion: 1
+
+deleteDatasources:
+- name: GoogleSheetsDatasource
+  orgId: 1
+  
+datasources:
+  - name: GoogleSheetsDatasource
+    type: grafana-googlesheets-datasource
+    enabled: true
+    jsonData:
+      authType: 'jwt'
+    secureJsonData:
+      jwt: '${google_jwt}'
+    version: 1
+    editable: true
+%{ endif }

--- a/grafana/input.tf
+++ b/grafana/input.tf
@@ -8,6 +8,7 @@ variable runtime_version { default = "6.5.1" }
 
 variable google_client_id { default = "" }
 variable google_client_secret { default = "" }
+variable google_jwt { default = "" }
 variable influxdb_credentials { default = null }
 
 variable admin_password {}
@@ -20,6 +21,9 @@ locals {
   grafana_ini_variables = {
     google_client_id     = var.google_client_id
     google_client_secret = var.google_client_secret
+  }
+  grafana_datasource_variables = {
+    google_jwt  = var.google_jwt
   }
   prometheus_datasource_variables = {
     prometheus_endpoint      = var.prometheus_endpoint


### PR DESCRIPTION
[Trello Ticket](https://trello.com/c/mGbZZoMQ/1340-users-against-cpu-memory)

Enabled the passing in  a JWT secret, to the Grafana module. Which in turn permits the data source access to the sheets that have been shared to the SP

Instructions on how to create an JWT are at:  [JWT](https://dfedigital.atlassian.net/wiki/spaces/BaT/pages/2562424899/Google+Sheets+Data+Source)

Testing was at:  [Grafana](https://grafana-dev-get-into-teaching.london.cloudapps.digital/d/uhhddQsGk/test?orgId=1&from=1614569519883&to=1614591119883)