### PR TITLE
EleasticSearch Datasource

### DIFF
--- a/grafana/README.md
+++ b/grafana/README.md
@@ -87,10 +87,15 @@ The following plugins are included. They are listed in the `plugins.txt` file:
 grafana-piechart-panel
 aidanmountford-html-panel
 simpod-json-datasource
+grafana-googlesheets-datasource
 ```
+### LOGIT (ELK) Integration
+By passing in the URL, Username and Password of an ELK stack end point, such as [Logit]( logit.io ) the deployment will include a datasource which you can use in dashboards to incorporate log data.
+The ELK datasource does not need to be added as it is a default datasorce.
 
 ### Google Integration
 Grafana supports integration with google logins. The ID must be configured and passed in to support this, following the [grafana instructions](https://grafana.com/docs/grafana/latest/auth/google/).
+It is also possible to include data from Google Sheets if a GOOGLE_JWT string is passed.
 
 ### Runtime version
 The default version is 6.5.1. It has been tested successfully with version 7.
@@ -110,5 +115,12 @@ module "grafana" {
      extra_datasources        = [file("${path.module}/datasources/elasticsearch.yml)",
      prometheus_endpoint      = "https://prometheus.london.cloudapps.digital"
      runtime_version          = "x.x.x"
+
+     google_jwt               = "very long and secret JWT String"
+
+     elasticsearch_credentials= { 
+             url = xxxx
+             username = yyyyy 
+             password = zzzzz }
 }
 ```

--- a/grafana/config.tf
+++ b/grafana/config.tf
@@ -38,6 +38,11 @@ data archive_file config {
     filename = "datasources/google-sheets.yml"
   }
 
+  source {
+    content  = templatefile("${path.module}/datasources/elasticsearch.yml.tmpl", local.grafana_datasource_variables)
+    filename = "datasources/elasticsearch.yml"
+  }
+
   dynamic "source" {
     for_each = local.dashboards
     content {

--- a/grafana/datasources/elasticsearch.yml.tmpl
+++ b/grafana/datasources/elasticsearch.yml.tmpl
@@ -1,0 +1,29 @@
+%{ if elasticsearch_url != "" }
+# config file version
+apiVersion: 1
+
+# list of datasources that should be deleted from the database
+deleteDatasources:
+- name: "Elasticseach"
+  orgId: 1
+
+# list of datasources to insert/update depending
+# what's available in the database
+datasources:
+- name:          Elasticseach
+  orgId:         1
+  type:          "elasticsearch"
+  access:        proxy
+  url:           "${elasticsearch_url}"
+  basicAuthUser: "${elasticsearch_username}"
+  database:      "logstash-*"
+  basicAuth:     true
+  isDefault:     false
+  editable:      false
+  secureJsonData:
+       basicAuthPassword:    "${elasticsearch_password}"
+  jsonData:    
+       esVersion:             70
+       timeField:             "@timestamp"
+
+%{ endif }

--- a/grafana/input.tf
+++ b/grafana/input.tf
@@ -10,6 +10,15 @@ variable google_client_id { default = "" }
 variable google_client_secret { default = "" }
 variable google_jwt { default = "" }
 variable influxdb_credentials { default = null }
+variable elasticsearch_credentials { 
+  type = map
+
+  default = {
+    url      = ""
+    username = ""
+    password = ""
+  }
+}
 
 variable admin_password {}
 variable json_dashboards { default = [] }
@@ -23,7 +32,10 @@ locals {
     google_client_secret = var.google_client_secret
   }
   grafana_datasource_variables = {
-    google_jwt  = var.google_jwt
+    google_jwt             = var.google_jwt
+    elasticsearch_url      = var.elasticsearch_credentials.url
+    elasticsearch_username = var.elasticsearch_credentials.username
+    elasticsearch_password = var.elasticsearch_credentials.password
   }
   prometheus_datasource_variables = {
     prometheus_endpoint      = var.prometheus_endpoint


### PR DESCRIPTION
### [Add default logit datasource in Grafana](https://trello.com/c/khN0ycpP/237-add-default-logit-datasource-in-grafana)

Adding a data source for Grafana, which will permit the access to an ELK stack via a URL, Primarily intended for accessing logit.io The call to Grafana will need URL/Username/Password

### Tested 
Tested deployment to [GiT Monitoring ](https://grafana-dev-get-into-teaching.london.cloudapps.digital/?orgId=1 )