### PR TITLE
default runtime version at highest level

### DIFF
--- a/prometheus_all/input.tf
+++ b/prometheus_all/input.tf
@@ -16,7 +16,7 @@ variable grafana_admin_password {}
 variable grafana_json_dashboards { default = [] }
 variable grafana_extra_datasources { default = [] }
 variable grafana_google_jwt { default = "" }
-variable grafana_runtime_version { default = "" }
+variable grafana_runtime_version { default = "6.5.1" }
 
 variable prometheus_memory { default = null }
 variable prometheus_disk_quota { default = null }


### PR DESCRIPTION
If the prometheus_all parameter has a "" it overrides the defaults bellow. 
This means we need to ensure prometheus_all defaults are set to reasonable figures