### PR TITLE
[teva-2163] Add @channel mention to alertmanager's template

### DIFF
--- a/alertmanager/config/slack.tmpl
+++ b/alertmanager/config/slack.tmpl
@@ -71,7 +71,7 @@
 {{ define "slack.monzo.pretext" -}}
     {{ range .Alerts }}
         {{- if .Annotations.summary }}
-            *{{ .Annotations.summary }}*
+         <!channel> *{{ .Annotations.summary }}*
         {{- end }}
     {{- end }}
 {{- end }}
@@ -87,4 +87,3 @@
         {{- end }}
     {{- end }}
 {{- end }}
-


### PR DESCRIPTION
Currently, when slack messages are sent to a channel, they are delivered quietly with no immediate attention or notification. This change is to include `@channel`, alongside the alert message annotation. So that, when messages are delivered, they come with Slack notification i.e. desktop notification.