### PR TITLE
Reduce prometheus local disk storage

### DIFF
--- a/prometheus/input.tf
+++ b/prometheus/input.tf
@@ -54,4 +54,14 @@ locals {
     internal_app_maps     = local.internal_app_maps
   }
   config_file = templatefile("${path.module}/templates/prometheus.yml.tmpl", local.template_variable_map)
+
+  # From https://github.com/prometheus/prometheus/blob/main/Dockerfile
+  default_command_list = [
+    "/bin/prometheus",
+    "--storage.tsdb.path=/prometheus",
+    "--config.file=/etc/prometheus/prometheus.yml",
+    "--web.console.libraries=/usr/share/prometheus/console_libraries",
+    "--web.console.templates=/usr/share/prometheus/consoles"
+  ]
+  default_command = join(" ", local.default_command_list)
 }

--- a/prometheus/resources.tf
+++ b/prometheus/resources.tf
@@ -9,7 +9,7 @@ resource "cloudfoundry_app" "prometheus" {
   space        = var.monitoring_space_id
   memory       = var.memory
   disk_quota   = var.disk_quota
-  command      = "echo \"$${PROM_CONFIG}\" > /etc/prometheus/prometheus.yml; echo \"$${ALERT_RULES}\" > /etc/prometheus/alert.rules; /bin/prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles"
+  command      = "echo \"$${PROM_CONFIG}\" > /etc/prometheus/prometheus.yml; echo \"$${ALERT_RULES}\" > /etc/prometheus/alert.rules; ${local.default_command} --storage.tsdb.retention.time 1d"
   docker_image = "prom/prometheus:v2.27.1"
   environment = {
     PROM_CONFIG = local.config_file


### PR DESCRIPTION
## What

Prometheus has been crashing because of high disk usage. We suspect it is because it stores metrics locally with a default retention of 15 days. Since we store metrics permanently in InfluxDB we can reduce it to 1 day.

Default options have been moved to input.tf for readability.

## Review
Deployed to https://grafana-bat-qa.london.cloudapps.digital
