### PR TITLE
Make alertmanager slack template configurable

### DIFF
--- a/alertmanager/input.tf
+++ b/alertmanager/input.tf
@@ -6,11 +6,12 @@ variable "config" { default = "" }
 
 variable "slack_url" { default = "" }
 variable "slack_channel" { default = "" }
+variable "slack_template" { default = "" }
 locals {
   alertmanager_variables = {
     slack_url     = var.slack_url
     slack_channel = var.slack_channel
   }
   config         = var.config == "" ? templatefile("${path.module}/config/alertmanager.yml.tmpl", local.alertmanager_variables) : var.config
-  slack_template = file("${path.module}/config/slack.tmpl")
+  slack_template = var.slack_template == "" ? file("${path.module}/config/slack.tmpl") : var.slack_template
 }

--- a/prometheus_all/input.tf
+++ b/prometheus_all/input.tf
@@ -8,6 +8,7 @@ variable "paas_exporter_password" {}
 variable "alertmanager_config" { default = "" }
 variable "alertmanager_slack_url" { default = "" }
 variable "alertmanager_slack_channel" { default = "" }
+variable "alertmanager_slack_template" { default = "" }
 variable "alert_rules" { default = "" }
 
 variable "grafana_google_client_id" { default = "" }

--- a/prometheus_all/resources.tf
+++ b/prometheus_all/resources.tf
@@ -60,6 +60,7 @@ module "alertmanager" {
   config                   = var.alertmanager_config
   slack_url                = var.alertmanager_slack_url
   slack_channel            = var.alertmanager_slack_channel
+  slack_template           = var.alertmanager_slack_template
 }
 
 module "grafana" {


### PR DESCRIPTION
Change the alertmanager config to made the slack template a default, and accept an override.

I've tested this out by using my fork here: https://github.com/DFE-Digital/early-careers-framework/blob/develop/terraform/monitoring/resources.tf