### PR TITLE
Add Route so alerts only trigger every 24h

### DIFF
--- a/alertmanager/README.md
+++ b/alertmanager/README.md
@@ -39,8 +39,20 @@ module alertmanager {
     summary: Alert when any user hits a rate limit (excluding the /csp_reports endpoint).
     runbook: https://dfedigital.atlassian.net/wiki/spaces/GGIT/pages/2152497153/Rate+Limit
 ```
+### Alert Routes
+A route has been added which will ensure alerts are only sent to slack once every 24 hours. To implement this route you need to add the label ```period: daily```
 
-The severity should be one of high, medium or low
+```yaml
+- alert: TooManyRequests
+  expr: 'sum(increase(tta_requests_total{path!~"csp_reports",status=~"429"}[1m])) > 0'
+  labels:
+    severity: high
+    period: daily
+  annotations:
+    summary: Alert when any user hits a rate limit (excluding the /csp_reports endpoint).
+    runbook: https://dfedigital.atlassian.net/wiki/spaces/GGIT/pages/2152497153/Rate+Limit
+```
+
 
 ### Templates
 A default set of slack templates have been provided

--- a/alertmanager/config/alertmanager.yml.tmpl
+++ b/alertmanager/config/alertmanager.yml.tmpl
@@ -8,6 +8,13 @@ route:
  receiver: 'slack-notifications'
  group_interval: 1m
  repeat_interval: 1h
+ group_by: [period]
+ routes:
+  - receiver: 'slack-notifications'
+    group_interval: 24h
+    repeat_interval: 24h
+    matchers:
+    - period="daily"
 
 templates:
   - './slack.tmpl'


### PR DESCRIPTION
## Task
By adding this route any alert tagged with the label daily will only send a message to slack once every 24 hours. this will stop regular repetitive warnings from swamping the slack channels

## Configuration in prometheus.
Add a label to your alert i.e:

```
name: DailyRoute
expr: sum(increase(cpu[1d])) > 90 and on() hour()  == 11
labels:
period: daily
severity: low
annotations:
dashboard: https://grafana-prod-get-into-teaching.london.cloudapps.digital/d/qZjcqcpGz/csp-violations?orgId=1&viewPanel=28
description: Test CSP violation.
summary: Test CSP violation.
```

In above example the monitoring only looks for an event in a certain time period, and then when it triggers it will only send an alert to slack once in that time period