### PR TITLE
Change prometheus storage retention

### DIFF
--- a/prometheus/input.tf
+++ b/prometheus/input.tf
@@ -74,5 +74,9 @@ locals {
     "--web.console.libraries=/usr/share/prometheus/console_libraries",
     "--web.console.templates=/usr/share/prometheus/consoles"
   ]
-  default_command = join(" ", local.default_command_list)
+  extra_command_list = [
+    "--storage.tsdb.retention.time 12h",
+    "--storage.tsdb.retention.size 1GB"
+  ]
+  command = join(" ", concat(local.default_command_list, local.extra_command_list))
 }

--- a/prometheus/resources.tf
+++ b/prometheus/resources.tf
@@ -9,7 +9,7 @@ resource "cloudfoundry_app" "prometheus" {
   space        = var.monitoring_space_id
   memory       = local.memory
   disk_quota   = local.disk_quota
-  command      = "echo \"$${PROM_CONFIG}\" > /etc/prometheus/prometheus.yml; echo \"$${ALERT_RULES}\" > /etc/prometheus/alert.rules; ${local.default_command} --storage.tsdb.retention.time 1h"
+  command      = "echo \"$${PROM_CONFIG}\" > /etc/prometheus/prometheus.yml; echo \"$${ALERT_RULES}\" > /etc/prometheus/alert.rules; ${local.command}"
   docker_image = "prom/prometheus:${local.docker_image_tag}"
   environment = {
     PROM_CONFIG = local.config_file


### PR DESCRIPTION
## What
Increase retention time to 12h as prometheus garbage collection period is 2h. It may avoid weird edge cases.
Now limiting disk size to 1G with the retention.size option.

## How to review
Check disk size in BAT: https://grafana-bat.london.cloudapps.digital/d/eF19g4RZx/cf-apps?orgId=1&refresh=10s&var-SpaceName=bat-prod&var-Applications=prometheus-bat&from=now-24h&to=now