### PR TITLE
[451] Drop guid label from paas exporter metrics

### DIFF
--- a/prometheus/templates/prometheus.yml.tmpl
+++ b/prometheus/templates/prometheus.yml.tmpl
@@ -23,6 +23,9 @@ scrape_configs:
     scrape_interval: ${exporter.scrape_interval}
     static_configs:
       - targets: [${exporter.endpoint}]
+    metric_relabel_configs:
+      - regex: guid
+        action: labeldrop
 %{ endfor ~}
 %{ for app in internal_app_maps ~}
   - job_name: ${ app.host }:${ app.port }


### PR DESCRIPTION
## What
The guid label changes at each application deployment. For the same metric it creates an infinity of time series.
Now it is dropped before getting ingested by prometheus.

## How to review
It's deployed to BAT QA. Check the guid label is not present: https://prometheus-readonly-bat-qa.london.cloudapps.digital/graph?g0.expr=cpu&g0.tab=1&g0.stacked=0&g0.show_exemplars=0&g0.range_input=6h

Even it was present in the exporter: https://paas-prometheus-exporter-bat-qa.london.cloudapps.digital/metrics
