### PR TITLE
[452] Remove or rename instance label from prometheus metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The scraper version of the Prometheus application has the configuration required
 
 ### Read Only
 The ReadOnly version of the Prometheus application is used by [Grafana](grafana/README.md) as a data source.
- 
+
 ## Minimal configuration
 
 ```hcl
@@ -115,6 +115,9 @@ If the port is not specified, the default Cloud Foundry port will be used (8080)
 
 [Internal routing](https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#internal-routes) must be configured so that prometheus can access them.
 `prometheus_all` outputs both prometheus app name and id to help create the network policy.
+
+**Note:** To allow useful aggregation and optimise time series storage, the applications should decorate the metrics with a label called `app_instance`
+representing the id of the Cloud Foundry app instance. It can be obtained at runtime from the `CF_INSTANCE_INDEX` environment variable.
 
 ## alertmanager
 A default configuration is provided but it doesn't send any notification. You can configure slack to publish to a webhook or provide your own configuration.

--- a/paas_prometheus_exporter/output.tf
+++ b/paas_prometheus_exporter/output.tf
@@ -1,8 +1,8 @@
 output "exporter" {
   value = {
-    endpoint = cloudfoundry_route.paas_prometheus_exporter.endpoint
-    name     = cloudfoundry_app.paas_prometheus_exporter.name
-    scheme   = "https"
+    endpoint     = cloudfoundry_route.paas_prometheus_exporter.endpoint
+    name         = cloudfoundry_app.paas_prometheus_exporter.name
+    scheme       = "https"
+    honor_labels = true
   }
 }
-

--- a/prometheus/templates/prometheus.yml.tmpl
+++ b/prometheus/templates/prometheus.yml.tmpl
@@ -35,6 +35,13 @@ scrape_configs:
       - ${app.host}
       type: 'A'
       port: ${app.port}
+    metric_relabel_configs:
+      - source_labels: [app_instance]
+        regex: app_instance
+        target_label: instance
+        action: replace
+      - regex: app_instance
+        action: labeldrop
 %{ endfor ~}
 
 %{ if include_alerting }


### PR DESCRIPTION
## What
The default instance label is not useful and it creates many useless time series because of its high cardinality. We replace it with the app instance number from Cloud foundry which is more useful.

Related to: https://github.com/DFE-Digital/apply-for-teacher-training/pull/6320

## How to review
Deployed to https://prometheus-bat-qa.london.cloudapps.digital/