### PR TITLE
[452] Fix prometheus relabelling

### DIFF
--- a/prometheus/templates/prometheus.yml.tmpl
+++ b/prometheus/templates/prometheus.yml.tmpl
@@ -37,7 +37,6 @@ scrape_configs:
       port: ${app.port}
     metric_relabel_configs:
       - source_labels: [app_instance]
-        regex: app_instance
         target_label: instance
         action: replace
       - regex: app_instance


### PR DESCRIPTION
## What
Fix error in prometheus relabel config: the instance label is not replaced

## How to review
Deployed to https://prometheus-bat-qa.london.cloudapps.digital/