### PR TITLE
[495] Selectively replace the instance label

### DIFF
--- a/prometheus/templates/prometheus.yml.tmpl
+++ b/prometheus/templates/prometheus.yml.tmpl
@@ -37,6 +37,7 @@ scrape_configs:
       port: ${app.port}
     metric_relabel_configs:
       - source_labels: [app_instance]
+        regex: (.+)
         target_label: instance
         action: replace
       - regex: app_instance


### PR DESCRIPTION
## What
The instance label should be replaced by app_instance if it is present.
It should be left untouched if app_instance is NOT present.

We now add a regex to make sure app_instance is not empty before
replacing instance.

## How to review
Test with metric with instance label, with and and without app_instance