### PR TITLE
Create GH Release and Tag on merge to master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Create Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  tag_and_release:
+    runs-on: ubuntu-20.04
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Tag and Create Release
+        uses: rymndhng/release-on-push-action@master
+        with:
+          bump_version_scheme: minor


### PR DESCRIPTION
This is an attempt to version each merge to master branch as a GH Release. With this,

other consuming repo can then pin to specific version or latest release. At this moment,

we don’t have the option to do that i.e. everyone gets the latest commit, which could sometimes

cause issues in the consumping repo through terraform.