### PR TITLE
Rename the postgres service key

### DIFF
--- a/postgres_prometheus_exporter/input.tf
+++ b/postgres_prometheus_exporter/input.tf
@@ -3,5 +3,5 @@ variable "monitoring_space_id" {}
 variable "postgres_service_instance" {}
 
 locals {
-  docker_image_tag = "v0.10.0"
+  docker_image_tag = "v0.10.1"
 }

--- a/postgres_prometheus_exporter/resource.tf
+++ b/postgres_prometheus_exporter/resource.tf
@@ -9,7 +9,7 @@ data "cloudfoundry_service_instance" "postgres_instance" {
 }
 
 resource "cloudfoundry_service_key" "postgres-key" {
-  name             = data.cloudfoundry_service_instance.postgres_instance.name
+  name             = "${data.cloudfoundry_service_instance.postgres_instance.name}-prometheus-exporter"
   service_instance = data.cloudfoundry_service_instance.postgres_instance.id
 }
 


### PR DESCRIPTION
## Context

A service key is created to allow the postgres_prometheus_exporter to connect to each app's postgres service.  This key is named after the app's postgres service which conflicts with a key created in the app's terraform file.  

## Changes proposed in this pull request

Renamed postgres servicekey to make it clear it belongs to the postgres_prometheus_exporter

## Guidance to review

The existing service keys for `apply-postgres-qa` & `teacher-training-api-postgres-qa` will be destroyed and replaced.  The service keys created during the deployment workflows for these applications have their own suffixes.
A new service key will be created for `register-postgres-qa`.

## Link to Trello card

https://trello.com/c/SfDpEYbL

## Things to check

- [x] Deploy to QA successfully