### PR TITLE
Add generic Postgres alerting

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The [prometheus_all module](#prometheus-all) is a good starting point as it incl
 - [Enable specific modules](#enable-specific-modules)
 - [Grafana](#grafana)
 - [PostgreSQL](#postgresql)
+- [Generic PostgreSQL alerting](#generic-postgresql-alerting)
 - [Redis Services](#redis-services)
 - [External exporters](#external-exporters)
 - [Internal applications](#internal-applications)
@@ -133,6 +134,46 @@ See [Grafana README](grafana/README.md)
 Basic metrics are available in the `CF databases` dashboard. The `PostgreSQL advanced` dashboard provides more advanced metrics via the `postgres_prometheus_exporter` module.
 
 See [postgres_prometheus_exporter README](postgres_prometheus_exporter/README.md)
+
+## Generic PostgreSQL alerting
+Generic Postgres alerting can be enabled for selected databases.
+
+This will add alerts that will trigger as specified below
+- Memory avail < 512MB
+- Cpu usage > 60%
+- Storage space avail < 1GB
+
+PreReqs.
+1. Monitoring must be configured for the postgres instances
+2. Alerting must already be configured for your service (alertmanager)
+
+Set the following variables in tf or env.tfvars.json file as per your configuration to enable generic alerting.
+
+**postgres_dashboard_url** (string): the grafana url for the cf-databases dashboard
+
+**alertable_postgres_services** (map): a map of the postgres instances to have alerting enabled, and optional alert thresholds.
+If any thresholds are not listed they will default as below
+- max_cpu = 60 (%)
+- min_mem = 1 (in Gb)
+- min_stg = 1 (in Gb)
+
+e.g. (for json format)
+```
+"postgres_dashboard_url": "https://grafana-service.london.cloudapps.digital/d/azzzBNMz"
+
+"alertable_postgres_services": {
+  "bat-qa/apply-postgres-qa": {
+    "max_cpu": 65,
+    "min_mem": 0.5,
+    "min_stg": 2
+  },
+  "bat-qa/register-postgres-qa": {
+  },
+  "bat-qa/teacher-training-api-postgres-qa": {
+    "min_mem": 0.5
+  }
+}
+```
 
 ## Redis Services
 If your application uses Redis you may want to include a Redis metrics exporter for each instance of Redis you use. This is accomplished by passing in an array of strings. Each string takes the form

--- a/prometheus/resources.tf
+++ b/prometheus/resources.tf
@@ -9,12 +9,13 @@ resource "cloudfoundry_app" "prometheus" {
   space              = var.monitoring_space_id
   memory             = local.memory
   disk_quota         = local.disk_quota
-  command            = "echo \"$${PROM_CONFIG}\" > /etc/prometheus/prometheus.yml; echo \"$${ALERT_RULES}\" > /etc/prometheus/alert.rules; ${local.command}"
+  command            = "echo \"$${PROM_CONFIG}\" > /etc/prometheus/prometheus.yml; echo \"$${ALERT_RULES}\" > /etc/prometheus/alert.rules; echo \"$${POSTGRES_ALERT_RULES}\" >> /etc/prometheus/alert.rules; ${local.command}"
   docker_image       = "prom/prometheus:${local.docker_image_tag}"
   docker_credentials = var.docker_credentials
   environment = {
-    PROM_CONFIG = local.config_file
-    ALERT_RULES = var.alert_rules
+    PROM_CONFIG          = local.config_file
+    ALERT_RULES          = var.alert_rules
+    POSTGRES_ALERT_RULES = local.postgres_alert_rules
   }
 
   service_binding {

--- a/prometheus/templates/pg_alert.rules.tmpl
+++ b/prometheus/templates/pg_alert.rules.tmpl
@@ -1,0 +1,42 @@
+
+- name: Postgres Memory Available
+  rules:
+%{ for instance in alertable_postgres_instances ~}
+  - alert: Postgres memory available low (instance - ${instance.pg_instance}, space - ${instance.pg_spacename})
+    expr: freeable_memory_bytes{service=~"${instance.pg_instance}",space="${instance.pg_spacename}"}/1024/1024/1024 < ${instance.min_mem}
+    for: 5m
+    annotations:
+      summary:     ${instance.pg_instance} low memory available
+      dashboard:   ${postgres_dashboard_url}&var-SpaceName=${instance.pg_spacename}&var-Services=${instance.pg_instance}
+      description: "Postgres Memory available is less than ${instance.min_mem} (current value: {{ $value }})"
+    labels:
+      instance:    ${instance.pg_instance}
+%{ endfor ~}
+
+- name: Postgres CPU Utilisation
+  rules:
+%{ for instance in alertable_postgres_instances ~}
+  - alert: Postgres CPU Utilisation high (instance - ${instance.pg_instance}, space - ${instance.pg_spacename})
+    expr: cpu_percent{service=~"${instance.pg_instance}",space="${instance.pg_spacename}"} > ${instance.max_cpu}
+    for: 5m
+    annotations:
+      summary:     ${instance.pg_instance} high CPU Utilisation
+      dashboard:   ${postgres_dashboard_url}&var-SpaceName=${instance.pg_spacename}&var-Services=${instance.pg_instance}
+      description: "Postgres CPU Utilisation is above ${instance.max_cpu}% (current value: {{ $value }})"
+    labels:
+      instance:    ${instance.pg_instance}
+%{ endfor ~}
+
+- name: Postgres Storage Utilisation
+  rules:
+%{ for instance in alertable_postgres_instances ~}
+  - alert: Postgres Storage available low (instance - ${instance.pg_instance}, space - ${instance.pg_spacename})
+    expr: free_storage_space_bytes{service=~"${instance.pg_instance}",space="${instance.pg_spacename}"}/1024/1024/1024 < ${instance.min_stg}
+    for: 5m
+    annotations:
+      summary:     ${instance.pg_instance} low storage available
+      dashboard:   ${postgres_dashboard_url}&var-SpaceName=${instance.pg_spacename}&var-Services=${instance.pg_instance}
+      description: "Postgres Storage available is less than ${instance.min_stg} (current value: {{ $value }})"
+    labels:
+      instance:    ${instance.pg_instance}
+%{ endfor ~}

--- a/prometheus_all/input.tf
+++ b/prometheus_all/input.tf
@@ -39,6 +39,11 @@ variable "alert_rules" {
   default     = ""
 }
 
+variable "postgres_dashboard_url" {
+  description = "Grafana dashboard url for Postgres"
+  default     = ""
+}
+
 variable "grafana_google_client_id" {
   description = "Google client id for Grafana Google single-sign-on"
   default     = ""
@@ -111,8 +116,12 @@ variable "redis_services" {
   default     = []
 }
 variable "postgres_services" {
-  description = "List of postrgres services for advanced monitoring and dashboard. [\"space1/postgres1\", \"space2/postgres2\", ...]"
+  description = "List of postgres services for advanced monitoring and dashboard. [\"space1/postgres1\", \"space2/postgres2\", ...]"
   default     = []
+}
+variable "alertable_postgres_services" {
+  description = "List of postgres services that will have alerting enabled. [\"space1/postgres1\", \"space2/postgres2\", ...]"
+  default     = {}
 }
 
 variable "external_exporters" {

--- a/prometheus_all/resources.tf
+++ b/prometheus_all/resources.tf
@@ -86,6 +86,8 @@ module "prometheus" {
   influxdb_service_instance_id = module.influxdb[0].service_instance_id
   alertmanager_endpoint        = contains(var.enabled_modules, "alertmanager") ? module.alertmanager[0].endpoint : ""
   alert_rules                  = var.alert_rules
+  alertable_postgres_services  = var.alertable_postgres_services
+  postgres_dashboard_url       = "${var.postgres_dashboard_url}/cf-databases?orgId=1&refresh=1m"
   memory                       = var.prometheus_memory
   disk_quota                   = var.prometheus_disk_quota
   internal_apps                = var.internal_apps


### PR DESCRIPTION
Adding Postgres alerting for memory, cpu and storage space.

Service is added to Postgres alerting by setting these variables in the calling app
(e.g. as per bat-infrastructure/monitoring)
-alertable_postgres_services
-postgres_dashboard_url
**Note that standard alerting must also be enabled**

Default settings to alert if
-Cpu usage > 60%
-Memory avail < 1GB
-Storage space avail < 1GB

https://trello.com/c/D42mz0JW/419-alerting-on-postgres-memory-cpu-limit

Config changes tested via 'make qa' 
