### PR TITLE
Refine HTTP requests panel on cf apps dashboard

### DIFF
--- a/grafana/dashboards/cf_apps.json
+++ b/grafana/dashboards/cf_apps.json
@@ -16,8 +16,8 @@
   "editable": true,
   "gnetId": 10063,
   "graphTooltip": 0,
-  "id": 5,
-  "iteration": 1642435504765,
+  "id": 6,
+  "iteration": 1650960370325,
   "links": [],
   "panels": [
     {
@@ -489,12 +489,19 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/.*failed requests/",
+          "$$hashKey": "object:174",
+          "alias": "/.*failed requests \\(server\\)/",
           "color": "#C4162A"
         },
         {
+          "$$hashKey": "object:175",
           "alias": "/.*total requests/",
           "color": "#1F60C4"
+        },
+        {
+          "$$hashKey": "object:188",
+          "alias": "/.*failed requests \\(client\\)/",
+          "color": "#FF9830"
         }
       ],
       "spaceLength": 10,
@@ -510,10 +517,18 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(rate(requests{space=\"$SpaceName\", app=~\"$Applications\",status_range=~\"0xx|4xx|5xx\"}[1m])) by (app) *60",
+          "expr": "sum(rate(requests{space=\"$SpaceName\", app=~\"$Applications\",status_range=~\"4xx\"}[1m])) by (app) *60",
           "interval": "",
-          "legendFormat": "{{app}} failed requests",
+          "legendFormat": "{{app}} failed requests (client)",
           "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(rate(requests{space=\"$SpaceName\", app=~\"$Applications\",status_range=~\"5xx\"}[1m])) by (app) *60",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{app}} failed requests (server)",
+          "refId": "C"
         }
       ],
       "thresholds": [],
@@ -990,8 +1005,8 @@
         "allValue": null,
         "current": {
           "selected": true,
-          "text": "All",
-          "value": "$__all"
+          "text": "apply-prod",
+          "value": "apply-prod"
         },
         "datasource": "Prometheus",
         "definition": "label_values(memory_utilization{space =~\"$SpaceName\"},app)",


### PR DESCRIPTION
### Context
The HTTP requests panel currently reports on total requests and failed requests, failed requests being defined as anything in the 4xx & 5xx ranges.

### Changes proposed in this pull request
Report on the 4xx and 5xx responses separately to align with the failed requests alert.  This makes the information presented in the single app more relevant to the alert that links to it and more useful generally for understanding the source of failed requests.  However, the multi app view is harder to read due to increased amount of data displayed.

### Guidance to review
- The change can be deployed to QA using the [test-http-request-dashboard](https://github.com/DFE-Digital/bat-infrastructure/tree/test-http-request-dashboard) branch of bat-infrastructure (already deployed, may need redeploying)
- Compare the [single app view](https://grafana-bat-qa.london.cloudapps.digital/d/eF19g4RZx/cf-apps?orgId=1&refresh=10s&var-SpaceName=bat-prod&var-Applications=apply-prod) and [multi app view](https://grafana-bat-qa.london.cloudapps.digital/d/eF19g4RZx/cf-apps?orgId=1&refresh=10s&var-SpaceName=bat-prod&var-Applications=All) to the current [prod instance](https://grafana-bat.london.cloudapps.digital/d/eF19g4RZx/cf-apps?orgId=1&refresh=10s&var-SpaceName=bat-prod&var-Applications=apply-prod)