### PR TITLE
Space name included in the grafana dashboard url

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The [prometheus_all module](#prometheus-all) is a good starting point as it incl
 - [Grafana](#grafana)
 - [PostgreSQL](#postgresql)
 - [Generic PostgreSQL alerting](#generic-postgresql-alerting)
+- [Generic Application alerting](#generic-application-alerting)
 - [Redis Services](#redis-services)
 - [External exporters](#external-exporters)
 - [Internal applications](#internal-applications)
@@ -200,11 +201,11 @@ e.g. (for json format)
 "apps_dashboard_url": "https://grafana-service.london.cloudapps.digital/d/azzzBNMz"
 
 "alertable_apps": {
-  "find-a-lost-trn-dev": {
+  "tra-dev/find-a-lost-trn-dev": {
   },
-  "qualified-teachers-api-dev": {
-    "response_threshold": 1
-  },
+  "tra-dev/qualified-teachers-api-dev": {
+    "response_threshold": 5
+  }
 }
 ```
 

--- a/prometheus/input.tf
+++ b/prometheus/input.tf
@@ -92,8 +92,9 @@ locals {
   }
 
   app_map = [for instance, settings in var.alertable_apps : {
-    app_name                       = instance
-    max_cpu                        = try(settings.max_cpu, 50)
+    app_name                       = split("/", instance)[1]
+    app_spacename                  = split("/", instance)[0]
+    max_cpu                        = try(settings.max_cpu, 60)
     max_mem                        = try(settings.max_mem, 60)
     max_disk                       = try(settings.max_disk, 60)
     max_crash_count                = try(settings.max_crash_count, 1)

--- a/prometheus/templates/app_alert.rules.tmpl
+++ b/prometheus/templates/app_alert.rules.tmpl
@@ -7,7 +7,7 @@ groups:
     for: 5m
     annotations:
       summary:     ${instance.app_name} High CPU Alert
-      dashboard:   ${cfapps_dashboard_url}&var-Applications=${instance.app_name}
+      dashboard:   ${cfapps_dashboard_url}&var-SpaceName=${instance.app_spacename}&var-Applications=${instance.app_name}
       description: "CPU usage has increased in the last 5 minutes (current value: {{ $value }}%)"
     labels:
       severity:    high
@@ -22,7 +22,7 @@ groups:
     for: 5m
     annotations:
       summary:     ${instance.app_name} high memory utilization
-      dashboard:   ${cfapps_dashboard_url}&var-Applications=${instance.app_name}
+      dashboard:   ${cfapps_dashboard_url}&var-SpaceName=${instance.app_spacename}&var-Applications=${instance.app_name}
       description: "Memory utilization has increased in the last 5 minutes (current value: {{ $value }}%)"
     labels:
       severity:    high
@@ -37,7 +37,7 @@ groups:
     for: 5m
     annotations:
       summary:     ${instance.app_name} high disk utilization
-      dashboard:   ${cfapps_dashboard_url}&var-Applications=${instance.app_name}
+      dashboard:   ${cfapps_dashboard_url}&var-SpaceName=${instance.app_spacename}&var-Applications=${instance.app_name}
       description: "Disk utilization has increased in the last 5 minutes (current value: {{ $value }})%"
     labels:
       severity:    high
@@ -52,7 +52,7 @@ groups:
     for: 5m
     annotations:
       summary:     At least one instance of ${instance.app_name} has crashed in the last 5 mins
-      dashboard:   ${cfapps_dashboard_url}&var-Applications=${instance.app_name}
+      dashboard:   ${cfapps_dashboard_url}&var-SpaceName=${instance.app_spacename}&var-Applications=${instance.app_name}
       description: At least one instance of ${instance.app_name} has crashed in the last 5 mins
     labels:
       severity:    high
@@ -67,7 +67,7 @@ groups:
     for: 5m
     annotations:
       summary:     High rate of failing requests
-      dashboard:   ${cfapps_dashboard_url}&var-Applications=${instance.app_name}
+      dashboard:   ${cfapps_dashboard_url}&var-SpaceName=${instance.app_spacename}&var-Applications=${instance.app_name}
       description: "The proportion of failed 5xx HTTP requests in the past 5 min is above ${instance.max_elevated_req_failure_count}% (current value: {{ humanizePercentage $value }})"
     labels:
       severity:    high
@@ -82,7 +82,7 @@ groups:
     for: 5m
     annotations:
       summary:     Slow running requests
-      dashboard:   ${cfapps_dashboard_url}&var-Applications=${instance.app_name}
+      dashboard:   ${cfapps_dashboard_url}&var-SpaceName=${instance.app_spacename}&var-Applications=${instance.app_name}
       description: "Requests in the 95 percentile taking longer than ${instance.response_threshold} second(s) (current value: {{ humanize $value}}s )"
     labels:
       severity:    high


### PR DESCRIPTION
Grafana dashboard url now takes to the correct space and app.

[x] [Attached to trello](https://trello.com/c/jdMCU23P/435-move-paas-app-alerting-to-cf-monitoring)