### PR TITLE
Fix alert link in slack notification

### DIFF
--- a/alertmanager/README.md
+++ b/alertmanager/README.md
@@ -53,6 +53,33 @@ A route has been added which will ensure alerts are only sent to slack once ever
     runbook: https://dfedigital.atlassian.net/wiki/spaces/GGIT/pages/2152497153/Rate+Limit
 ```
 
+### Testing Alertmanager
+
+Install `amtool` with `go get github.com/prometheus/alertmanager/cmd/amtool` if testing locally. `amtool` is already installed in alertmanager paas instance.
+1. Check if alertmanager is accessible
+
+  `amtool --alertmanager.url=https://alertmanager-tra-monitoring-dev.london.cloudapps.digital config show`
+  Above command displays alertmanager.yaml config.
+
+2. Checking where alerts go
+
+  `amtool --alertmanager.url=https://alertmanager-tra-monitoring-dev.london.cloudapps.digital config routes show`
+
+	Routing tree:
+   	└──	default-route  receiver: slack-notifications
+			├── {period="daily"}  receiver: slack-notifications
+			└── {period="'out-of-hours'"}  receiver: slack-notifications
+
+3. ` amtool --alertmanager.url=https://alertmanager-tra-monitoring-dev.london.cloudapps.digital config routes test period=daily `
+   prints `slack-notifications`
+
+### Simulating an alert
+
+Either `ssh` into alertmanager instance or run below command locally.
+
+`amtool --alertmanager.url=https://alertmanager-tra-monitoring-dev.london.cloudapps.digital alert add this-is-a-test-alert period=hourly`
+
+Above command will send a test alert to the SLACK_WEBHOOK.
 
 ### Templates
 A default set of slack templates have been provided

--- a/alertmanager/config/alertmanager.yml.tmpl
+++ b/alertmanager/config/alertmanager.yml.tmpl
@@ -45,6 +45,7 @@ receivers:
     send_resolved: true
     title: '{{ template "slack.monzo.title" . }}'
     pretext: '{{ template "slack.monzo.pretext" . }}'
+    title_link: '{{ template "__alertmanagerURL" . }}'
     text: '{{ template "slack.monzo.text" . }}'
     color: '{{ template "slack.monzo.color" . }}'
     actions:

--- a/alertmanager/config/slack.tmpl
+++ b/alertmanager/config/slack.tmpl
@@ -87,3 +87,7 @@
         {{- end }}
     {{- end }}
 {{- end }}
+
+{{ define "__alertmanagerURL" -}}
+    {{ .ExternalURL }}/#/alerts?receiver=slack-notifications
+{{ end }}

--- a/alertmanager/resources.tf
+++ b/alertmanager/resources.tf
@@ -9,7 +9,7 @@ resource "cloudfoundry_app" "alertmanager" {
   space              = var.monitoring_space_id
   docker_image       = "prom/alertmanager:${local.docker_image_tag}"
   docker_credentials = var.docker_credentials
-  command            = "echo \"$${SLACK_TEMPLATE}\" > slack.tmpl; echo \"$${CONFIG}\" > alertmanager.yml ; alertmanager --web.listen-address=:$${PORT} --config.file=alertmanager.yml"
+  command            = "echo \"$${SLACK_TEMPLATE}\" > slack.tmpl; echo \"$${CONFIG}\" > alertmanager.yml ; alertmanager --web.listen-address=:$${PORT} --web.external-url=https://${cloudfoundry_route.alertmanager.hostname}.${data.cloudfoundry_domain.cloudapps.name} --config.file=alertmanager.yml"
   routes {
     route = cloudfoundry_route.alertmanager.id
   }


### PR DESCRIPTION
Slack notification title was pointing to internal/default URL.  Now it's changed to point to alertmanager external URL.

[x][Attach to trello](https://trello.com/c/4T0PTPm9/450-fix-alert-link-in-slack-notification)