### PR TITLE
[592] Grafana anonymous authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Collection of [terraform](https://www.terraform.io/) modules to deploy the [prom
 - Metrics-based alerts can be created in prometheus and processed by [alertmanager](https://prometheus.io/docs/alerting/) to send to Slack, email, pagerduty, etc
 - Finally, the metrics are available in [grafana](https://grafana.com/) to build dashboards, help troubleshooting and create alerts.
 
-The [prometheus_all module](#prometheus-all) is a good starting point as it includes all the other modules.
+The [prometheus_all module](#prometheus-all) is a good starting point as it includes all the other modules. Check the variables in [prometheus_all](https://github.com/DFE-Digital/cf-monitoring/blob/master/prometheus_all/input.tf) for a description of all configuration options.
 
 ## Source
 

--- a/grafana/config/grafana.ini
+++ b/grafana/config/grafana.ini
@@ -9,3 +9,11 @@ token_url = https://accounts.google.com/o/oauth2/token
 allowed_domains = digital.education.gov.uk
 allow_sign_up = true
 %{ endif }
+
+%{ if enable_anonymous_auth }
+[auth.anonymous]
+enabled = true
+org_name = Main Org.
+org_role = Viewer
+hide_version = true
+%{ endif }

--- a/grafana/input.tf
+++ b/grafana/input.tf
@@ -10,6 +10,8 @@ variable "runtime_version" { default = "" }
 variable "google_client_id" { default = "" }
 variable "google_client_secret" { default = "" }
 variable "google_jwt" { default = "" }
+variable "enable_anonymous_auth" { default = false }
+
 variable "influxdb_credentials" { default = null }
 variable "elasticsearch_credentials" {
   type = map(any)
@@ -30,8 +32,9 @@ locals {
   dashboard_list          = fileset(path.module, "dashboards/*.json")
   dashboards              = [for f in local.dashboard_list : file("${path.module}/${f}")]
   grafana_ini_variables = {
-    google_client_id     = var.google_client_id
-    google_client_secret = var.google_client_secret
+    google_client_id      = var.google_client_id
+    google_client_secret  = var.google_client_secret
+    enable_anonymous_auth = var.enable_anonymous_auth
   }
   grafana_datasource_variables = {
     google_jwt             = var.google_jwt

--- a/prometheus_all/input.tf
+++ b/prometheus_all/input.tf
@@ -98,6 +98,11 @@ variable "grafana_elasticsearch_credentials" {
   }
 }
 
+variable "grafana_anonymous_auth" {
+  description = "Enable anonymous readonly access to Grafana"
+  default     = false
+}
+
 variable "docker_credentials" {
   description = "Credentials for Dockerhub. Map of {username, password}."
   type        = map(any)

--- a/prometheus_all/resources.tf
+++ b/prometheus_all/resources.tf
@@ -126,4 +126,5 @@ module "grafana" {
   influxdb_credentials       = module.influxdb[0].credentials
   runtime_version            = var.grafana_runtime_version
   elasticsearch_credentials  = var.grafana_elasticsearch_credentials
+  enable_anonymous_auth      = var.grafana_anonymous_auth
 }


### PR DESCRIPTION
## What
Add a variable to enable anonymous readonly access to the Grafana dashboards and metrics. This is useful to be able to present on logged out TV screens.

## How to review
Sign out and access https://grafana-bat-qa.london.cloudapps.digital/ 