### PR TITLE
Set alert expr to use equal instead of regex equal

### DIFF
--- a/prometheus/templates/pg_alert.rules.tmpl
+++ b/prometheus/templates/pg_alert.rules.tmpl
@@ -3,7 +3,7 @@ groups:
   rules:
 %{ for instance in alertable_postgres_instances ~}
   - alert: Postgres memory available low (instance - ${instance.pg_instance}, space - ${instance.pg_spacename})
-    expr: min_over_time(freeable_memory_bytes{service=~"${instance.pg_instance}",space="${instance.pg_spacename}"}[15m])/1024/1024/1024 < ${instance.min_mem}
+    expr: min_over_time(freeable_memory_bytes{service="${instance.pg_instance}",space="${instance.pg_spacename}"}[15m])/1024/1024/1024 < ${instance.min_mem}
     for: 5m
     annotations:
       summary:     ${instance.pg_instance} low memory available
@@ -19,7 +19,7 @@ groups:
   rules:
 %{ for instance in alertable_postgres_instances ~}
   - alert: Postgres CPU Utilisation high (instance - ${instance.pg_instance}, space - ${instance.pg_spacename})
-    expr: max_over_time(cpu_percent{service=~"${instance.pg_instance}",space="${instance.pg_spacename}"}[15m]) > ${instance.max_cpu}
+    expr: max_over_time(cpu_percent{service="${instance.pg_instance}",space="${instance.pg_spacename}"}[15m]) > ${instance.max_cpu}
     for: 5m
     annotations:
       summary:     ${instance.pg_instance} high CPU Utilisation
@@ -35,7 +35,7 @@ groups:
   rules:
 %{ for instance in alertable_postgres_instances ~}
   - alert: Postgres Storage available low (instance - ${instance.pg_instance}, space - ${instance.pg_spacename})
-    expr: min_over_time(free_storage_space_bytes{service=~"${instance.pg_instance}",space="${instance.pg_spacename}"}[15m])/1024/1024/1024 < ${instance.min_stg}
+    expr: min_over_time(free_storage_space_bytes{service="${instance.pg_instance}",space="${instance.pg_spacename}"}[15m])/1024/1024/1024 < ${instance.min_stg}
     for: 5m
     annotations:
       summary:     ${instance.pg_instance} low storage available


### PR DESCRIPTION
Alter alert expression to use = instead of =~ (regex equal)
otherwise the expression can include multiple services or apps
e.g.
=~ register-prod 
will include register-prod and register-proddata in the same alert

For bat-infrastructure
- tested updated expressions work as expected in prometheus, 
- deployed manually to QA monitoring


